### PR TITLE
fix missing comma in timing_line

### DIFF
--- a/src/2d/dig/valout.f90
+++ b/src/2d/dig/valout.f90
@@ -491,9 +491,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
              status='unknown', action='write', position='append')
              !status='old', action='write', position='append')
 
-    timing_line = "(e16.6, ', ', e16.6, ', ', e16.6,"
+    timing_line = "(e16.6, ', ', e16.6, ', ', e16.6"
     do level=1, mxnest
-        timing_substr = "', ', e16.6, ', ', e16.6, ', ', e16.6"
+        timing_substr = ", ', ', e16.6, ', ', e16.6, ', ', e16.6"
         timing_line = trim(timing_line) // timing_substr
     end do
     timing_line = trim(timing_line) // ")"


### PR DESCRIPTION
As was done for other packages e.g. in https://github.com/clawpack/geoclaw/pull/651