### PR TITLE
new src/2d/dig-bouss for merging geoclaw/src/2d/bouss with dig

### DIFF
--- a/src/2d/dig-bouss/Makefile.dclaw-bouss
+++ b/src/2d/dig-bouss/Makefile.dclaw-bouss
@@ -1,0 +1,222 @@
+#get the directory of this makefile
+AMRLIB:=$(CLAW)/amrclaw/src/2d
+GEOLIB:=$(CLAW)/geoclaw/src/2d/shallow
+BOUSSLIB:=$(CLAW)/geoclaw/src/2d/bouss
+DIGLIB:=$(CLAW)/dclaw/src/2d/dig
+DIGBOUSS:=$(CLAW)/dclaw/src/2d/dig-bouss
+
+
+#list of common modules for amr 2d codes
+COMMON_MODULES += \
+ $(BOUSSLIB)/amr_module.f90 \
+ $(AMRLIB)/regions_module.f90 \
+ $(AMRLIB)/adjoint_module.f90 \
+ $(BOUSSLIB)/bouss_module.f90  \
+
+
+#list of common modules needed for geoclaw codes
+COMMON_MODULES += \
+ $(GEOLIB)/utility_module.f90 \
+ $(GEOLIB)/geoclaw_module.f90 \
+ $(GEOLIB)/topo_module.f90 \
+ $(GEOLIB)/fgmax_module.f90 \
+ $(GEOLIB)/surge/model_storm_module.f90 \
+ $(GEOLIB)/surge/data_storm_module.f90 \
+ $(GEOLIB)/surge/storm_module.f90 \
+ $(GEOLIB)/gauges_module.f90 \
+ $(GEOLIB)/multilayer/multilayer_module.f90 \
+ $(GEOLIB)/friction_module.f90 \
+ $(DIGLIB)/refinement_module.f90 \
+ $(GEOLIB)/adjointsup_module.f90 \
+ $(GEOLIB)/fgout_module.f90 \
+
+#list of common modules needed for dclaw codes
+COMMON_MODULES += \
+ $(DIGLIB)/digclaw_module.f90 \
+ $(DIGLIB)/qinit_module.f90 \
+ $(DIGLIB)/auxinit_module.f90 \
+
+
+# list of source files from AMR library.
+COMMON_SOURCES += \
+  $(AMRLIB)/prefilp.f90 \
+  $(AMRLIB)/trimbd.f90 \
+  $(AMRLIB)/intfil.f90 \
+  $(AMRLIB)/flagregions2.f90  \
+  $(AMRLIB)/quick_sort1.f \
+  $(AMRLIB)/quick_sort_reals.f \
+  $(AMRLIB)/estdt.f \
+  $(AMRLIB)/check4nans.f90 \
+  $(AMRLIB)/init_iflags.f \
+  $(AMRLIB)/igetsp.f \
+  $(AMRLIB)/reclam.f \
+  $(AMRLIB)/birect.f \
+  $(AMRLIB)/cleanup.f \
+  $(AMRLIB)/colate2.f \
+  $(AMRLIB)/bufnst2.f \
+  $(AMRLIB)/flagger.f \
+  $(AMRLIB)/fixcapaq.f \
+  $(AMRLIB)/flglvl2.f \
+  $(AMRLIB)/fluxad.f \
+  $(AMRLIB)/fluxsv.f \
+  $(AMRLIB)/grdfit2.f \
+  $(AMRLIB)/moment.f90 \
+  $(AMRLIB)/nestck2.f \
+  $(AMRLIB)/prepc.f \
+  $(AMRLIB)/prepf.f \
+  $(AMRLIB)/projec2.f \
+  $(AMRLIB)/signs.f \
+  $(AMRLIB)/findcut.f \
+  $(AMRLIB)/smartbis.f \
+  $(AMRLIB)/putnod.f \
+  $(AMRLIB)/putsp.f \
+  $(AMRLIB)/regrid.f \
+  $(AMRLIB)/setuse.f \
+  $(AMRLIB)/stst1.f \
+  $(AMRLIB)/nodget.f \
+  $(AMRLIB)/basic.f \
+  $(AMRLIB)/outval.f \
+  $(AMRLIB)/copysol.f \
+  $(AMRLIB)/outvar.f \
+  $(AMRLIB)/outmsh.f \
+  $(AMRLIB)/outtre.f \
+  $(AMRLIB)/domain.f  \
+  $(AMRLIB)/cellave.f \
+  $(AMRLIB)/fdisc.f \
+  $(AMRLIB)/fss.f \
+  $(AMRLIB)/zeroin.f \
+  $(AMRLIB)/setflags.f \
+  $(AMRLIB)/shiftset2.f \
+  $(AMRLIB)/conck.f \
+  $(AMRLIB)/domshrink.f \
+  $(AMRLIB)/domprep.f \
+  $(AMRLIB)/domup.f \
+  $(AMRLIB)/domcopy.f \
+  $(AMRLIB)/setdomflags.f \
+  $(AMRLIB)/setIndices.f \
+  $(AMRLIB)/coarseGridFlagSet.f \
+  $(AMRLIB)/addflags.f \
+  $(AMRLIB)/baseCheck.f \
+  $(AMRLIB)/drivesort.f \
+  $(AMRLIB)/flagcheck.f \
+  $(AMRLIB)/domgrid.f \
+  $(AMRLIB)/setPhysBndryFlags.f \
+  $(AMRLIB)/griddomup.f \
+  $(AMRLIB)/griddomcopy.f \
+  $(AMRLIB)/griddomshrink.f \
+  $(AMRLIB)/intcopy.f \
+  $(AMRLIB)/preintcopy.f \
+  $(AMRLIB)/icall.f \
+  $(AMRLIB)/preicall.f \
+  $(AMRLIB)/inlinelimiter.f \
+  $(AMRLIB)/cstore.f \
+  $(AMRLIB)/saveqc.f \
+  $(AMRLIB)/opendatafile.f \
+  $(AMRLIB)/init_bndryList.f \
+  $(AMRLIB)/resize_bndryList.f \
+  $(AMRLIB)/init_nodes.f90 \
+  $(AMRLIB)/restrt_nodes.f90 \
+  $(AMRLIB)/resize_nodes.f90 \
+  $(AMRLIB)/init_alloc.f90 \
+  $(AMRLIB)/restrt_alloc.f90 \
+  $(AMRLIB)/resize_alloc.f90
+
+# list of source files from GEOCLAW library.
+COMMON_SOURCES += \
+  $(GEOLIB)/setprob.f90 \
+  $(GEOLIB)/topo_update.f90 \
+  $(GEOLIB)/cellgridintegrate2.f \
+  $(GEOLIB)/topointegral.f \
+  $(GEOLIB)/bilinearintegral.f \
+  $(GEOLIB)/src1d.f90 \
+  $(GEOLIB)/stepgrid.f \
+  $(GEOLIB)/step2.f90 \
+  $(GEOLIB)/qad.f \
+  $(GEOLIB)/bc2amr.f90 \
+  $(GEOLIB)/upbnd.f  \
+  $(GEOLIB)/setgrd.f \
+  $(GEOLIB)/gfixup.f \
+  $(GEOLIB)/ginit.f \
+  $(GEOLIB)/getmaxspeed.f90 \
+  $(GEOLIB)/advanc.f \
+  $(GEOLIB)/fgmax_read.f90 \
+  $(GEOLIB)/fgmax_frompatch.f90 \
+  $(GEOLIB)/fgmax_interp.f90 \
+  $(GEOLIB)/fgmax_values.f90 \
+  $(GEOLIB)/fgmax_finalize.f90 \
+  $(GEOLIB)/check.f \
+  $(GEOLIB)/restrt.f \
+  $(GEOLIB)/errest.f \
+  $(GEOLIB)/errf1.f \
+  $(GEOLIB)/coarsen.f \
+  $(GEOLIB)/auxcoarsen.f \
+  $(GEOLIB)/prepbigstep.f \
+  $(GEOLIB)/prepregstep.f \
+  $(GEOLIB)/set_eta_init.f90 \
+
+
+# list of source files from DIGCLAW library.
+COMMON_SOURCES += \
+  $(DIGBOUSS)/flag2refine2.f90  \
+  $(DIGBOUSS)/qinit.f90 \
+  $(DIGBOUSS)/b4step2.f90 \
+  $(DIGBOUSS)/flux2fw.f \
+  $(DIGLIB)/riemannsolvers_dclaw.f \
+  $(DIGLIB)/rpn2_dclaw.f \
+  $(DIGLIB)/rpt2_dclaw.f \
+  $(DIGLIB)/entrainment.f90 \
+  $(DIGLIB)/mp_update.f90 \
+
+
+# list of source files from BOUSSLIB library.  **NEED TO CLEAN BOUSS UP FIRST**
+COMMON_SOURCES += \
+  $(BOUSSLIB)/bound.f90 \
+  $(BOUSSLIB)/flagregions2.f90  \
+  $(BOUSSLIB)/flagger.f \
+  $(BOUSSLIB)/flglvl2.f \
+  $(BOUSSLIB)/grdfit2.f \
+  $(BOUSSLIB)/stst1.f \
+  $(BOUSSLIB)/outval.f \
+  $(BOUSSLIB)/outmsh.f \
+  $(BOUSSLIB)/domain.f  \
+  $(BOUSSLIB)/cellave.f \
+  $(BOUSSLIB)/fdisc.f \
+  $(BOUSSLIB)/fss.f \
+  $(BOUSSLIB)/zeroin.f \
+  $(BOUSSLIB)/stepgrid.f \
+  $(BOUSSLIB)/bc2amr.f90 \
+  $(BOUSSLIB)/setgrd.f \
+  $(BOUSSLIB)/advanc_splitRev2Calls.f \
+  $(BOUSSLIB)/regrid.f \
+  $(BOUSSLIB)/conck.f90 \
+  $(BOUSSLIB)/check.f \
+  $(BOUSSLIB)/restrt.f \
+  $(BOUSSLIB)/setMatrixIndex.f90 \
+  $(BOUSSLIB)/setBoussFlag.f90 \
+  $(BOUSSLIB)/implicit_update_bouss_2Calls.f90 \
+  $(BOUSSLIB)/prepBuildSparseMatrixSGNcrs.f90 \
+  $(BOUSSLIB)/buildSparseMatrixSGNcrs.f90 \
+  $(BOUSSLIB)/prepBuildSparseMatrixSGNcoo.f90 \
+  $(BOUSSLIB)/buildSparseMatrixSGNcoo.f90 \
+  $(BOUSSLIB)/buildSparseMatrixSGNcoo_blocks.f90 \
+  $(BOUSSLIB)/buildSparseMatrixMScoo.f90 \
+  $(BOUSSLIB)/compressOut.f \
+  $(BOUSSLIB)/matvec.f90 \
+  $(BOUSSLIB)/testSoln.f90 \
+  $(BOUSSLIB)/petsc_driver.f90 \
+  $(BOUSSLIB)/lookAtGrid.f90 \
+  $(BOUSSLIB)/resetBoussStuff.f \
+  $(BOUSSLIB)/simpleBound.f90 \
+  $(BOUSSLIB)/umfpack_support.f \
+
+
+# list of source files from DIGBOUSS library.
+COMMON_SOURCES += \
+  $(DIGBOUSS)/tick.f \
+  $(DIGBOUSS)/amr2.f90 \
+  $(DIGBOUSS)/filval.f90 \
+  $(DIGBOUSS)/filpatch.f90 \
+  $(DIGBOUSS)/update.f90 \
+  $(DIGBOUSS)/valout.f90 \
+  $(DIGBOUSS)/setaux.f90 \
+  $(DIGBOUSS)/src2.f90 \

--- a/src/2d/dig-bouss/Makefile.dclaw-bouss
+++ b/src/2d/dig-bouss/Makefile.dclaw-bouss
@@ -168,7 +168,9 @@ COMMON_SOURCES += \
   $(DIGLIB)/mp_update.f90 \
 
 
-# list of source files from BOUSSLIB library.  **NEED TO CLEAN BOUSS UP FIRST**
+# list of source files from BOUSSLIB library.
+# ** NEED TO CLEAN BOUSS UP FIRST **
+# ** some routines are listed above too, which to use?? **
 COMMON_SOURCES += \
   $(BOUSSLIB)/bound.f90 \
   $(BOUSSLIB)/flagregions2.f90  \


### PR DESCRIPTION
First pass at `Makefile.dig-bouss`, but the list of BOUSSLIB routines includes repetitions and needs to be fixed after cleaning up `geoclaw/src/2d/bouss`.
    
The list of DIGBOUSS sources in the Makefile are the ones that were changed in both dig and bouss, but maybe some of these can be cleaned up for more general use (e.g. `valout.f90`).